### PR TITLE
fix: jpaAuditingHandler 빈 충돌 회피 (common + JpaAuditingConfig) 

### DIFF
--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -4,6 +4,9 @@ server:
   port: 8202
 
 spring:
+  main:
+    # common 의 JpaConfig.jpaAuditingHandler 와 delivery 자체 JpaAuditingConfig 의 동일 빈 충돌 회피.
+    allow-bean-definition-overriding: true
   config:
     import: "optional:configserver:http://config-server"
   cloud:


### PR DESCRIPTION
K8s 부팅 BeanDefinitionOverrideException 일어납니다. 
빈 오버리이딩 추가했습니다.

## 🌱 설명

이 PR에서 어떤 작업을 했는지 간략하게 설명해주세요.

## 📌 관련 이슈

close #

## ✅ 주요 변경 사항

-
-
-

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.
