### PR TITLE
chore(delivery): batch cron 임시 10초마다 (부하 테스트용)

### DIFF
--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -56,8 +56,13 @@ eureka:
 # k8s 프로필이 값 못 받음. prod 와 동일 cron 값 박음 (매일 9시, 14시).
 delivery:
   batch:
-    am-cron: "0 0 9 * * *"
-    pm-cron: "0 0 14 * * *"
+    # 원래값 (부하 테스트 끝나면 복귀):
+    # am-cron: "0 0 9 * * *"
+    # pm-cron: "0 0 14 * * *"
+    # 부하 테스트 동안 batch 흐름 검증 위해 임시로 매 10초 fire (am-cron 만).
+    # pm 은 "-" 로 비활성 (Spring 6 의 disabled cron) — am 만 fire 해서 중복 batch 회피.
+    am-cron: "*/10 * * * * *"
+    pm-cron: "-"
   # OutboxPoller @Scheduled placeholder. config-repo prod 와 동일 (10초 주기).
   outbox:
     scheduler-cron: "*/10 * * * * *"


### PR DESCRIPTION
## 🌱 설명

원래 `am-cron: 0 0 9 * * *` / `pm-cron: 0 0 14 * * *` — 매일 1번씩 → 부하 테스트 임의 시간에 batch 흐름 검증 불가.

임시로 am-cron 만 10초마다 fire (`*/10 * * * * *`). pm 은 Spring 6 의 disabled cron `-` 으로 비활성해서 중복 batch 회피. 원래 값은 주석 보존.

## 📌 관련 이슈

close #

## ✅ 주요 변경 사항

- `application-k8s.yml` 의 `delivery.batch.am-cron` → `*/10 * * * * *`
- `delivery.batch.pm-cron` → `-` (disabled)

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

부하 테스트 끝나면 원래 값 (주석에 보존됨) 으로 복귀 PR. config-repo 는 안 건드림 (환경 전역 영향 회피).