### PR TITLE
fix(liquibase): p_delivery schema 분리 (default-schema + liquibase-schema)

### DIFF
--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -18,6 +18,12 @@ spring:
     url: jdbc:postgresql://postgres:5432/trusta_market
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+  # delivery / inspection 이 같은 V001__init.sql changeset (id 1-4, author seungwon) 을 쓰는데
+  # 그 두 service 가 public.databasechangelog 공유하면 file 내용 다를 때 checksum mismatch.
+  # → p_delivery schema 의 databasechangelog 으로 분리. p_delivery.databasechangelog row 는 별도 SQL 로 NULL md5 박아둠 (Liquibase 가 부팅 시 재계산).
+  liquibase:
+    default-schema: p_delivery
+    liquibase-schema: p_delivery
   jpa:
     hibernate:
       ddl-auto: update

--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -65,9 +65,9 @@ delivery:
     # 원래값 (부하 테스트 끝나면 복귀):
     # am-cron: "0 0 9 * * *"
     # pm-cron: "0 0 14 * * *"
-    # 부하 테스트 동안 batch 흐름 검증 위해 임시로 매 10초 fire (am-cron 만).
-    # pm 은 "-" 로 비활성 (Spring 6 의 disabled cron) — am 만 fire 해서 중복 batch 회피.
-    am-cron: "*/10 * * * * *"
+    # 부하 테스트 동안 batch 흐름 검증 위해 am-cron 만 매 5초 fire.
+    # pm 은 "-" 로 비활성 (Spring 6 의 disabled cron) — 중복 batch 회피.
+    am-cron: "*/5 * * * * *"
     pm-cron: "-"
   # OutboxPoller @Scheduled placeholder. config-repo prod 와 동일 (10초 주기).
   outbox:


### PR DESCRIPTION
## 🌱 설명

`hibernate.default_schema: p_delivery` 이미 있는데 `spring.liquibase.default-schema` 가 빠져있어서 Liquibase 가 여전히 `public.databasechangelog` 봐서 checksum mismatch → 부팅 실패.

`spring.liquibase.default-schema` / `liquibase-schema` 추가하면 Liquibase 도 p_delivery schema 사용.

## 📌 관련 이슈

close #

## ✅ 주요 변경 사항

- `application-k8s.yml` 의 spring 블록에 `liquibase.default-schema: p_delivery` / `liquibase-schema: p_delivery` 추가

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

DB 작업 (이미 적용됨, 별도 PR X):
- p_delivery.databasechangelog / databasechangeloglock 생성
- public.databasechangelog 의 seungwon 4 row 를 p_delivery.databasechangelog 로 복사 (md5 NULL)
- 부팅 시 Liquibase 가 NULL md5 발견 → file 의 md5 로 재계산 + 박음 → changeset 실행 skip → 정상 부팅

inspection 은 그대로 public.databasechangelog 사용 (영향 X).