### PR TITLE
fix(yaml): delivery duplicate liquibase 키 제거 — 부팅 fail 해소

### DIFF
--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -18,12 +18,6 @@ spring:
     url: jdbc:postgresql://postgres:5432/trusta_market
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
-  # delivery / inspection 이 같은 V001__init.sql changeset (id 1-4, author seungwon) 을 쓰는데
-  # 그 두 service 가 public.databasechangelog 공유하면 file 내용 다를 때 checksum mismatch.
-  # → p_delivery schema 의 databasechangelog 으로 분리. p_delivery.databasechangelog row 는 별도 SQL 로 NULL md5 박아둠 (Liquibase 가 부팅 시 재계산).
-  liquibase:
-    default-schema: p_delivery
-    liquibase-schema: p_delivery
   jpa:
     hibernate:
       ddl-auto: validate


### PR DESCRIPTION
## 🌱 설명

`liquibase:` 키가 application-k8s.yml 에 2번 박혀 YAML duplicate key parse error → pod CrashLoopBackOff.

다른 service (user/wallet/payment) 의 표준 패턴 (`enabled` + `change-log` + schema) 와 일치시키기 위해 첫 번째 블록 (PR #31 의 schema-only) 제거. 두 번째 블록 (팀 표준) 유지.

## ✅ 주요 변경 사항

- application-k8s.yml 의 첫 번째 `liquibase:` 블록 (line 24-26) 제거
- 두 번째 `liquibase:` 블록 (enabled + change-log + schema) 그대로

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

`change-log: db.changelog-master.yml` (실 file 은 `.yaml`) 오타는 별도 PR.