### PR TITLE
fix(yaml): delivery duplicate liquibase 제거 (PR #31 의 schema 분리 살림)

### DIFF
--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -32,11 +32,6 @@ spring:
         default_schema: p_delivery
         dialect: org.hibernate.dialect.PostgreSQLDialect
     open-in-view: false
-  liquibase:
-    enabled: true
-    change-log: classpath:db/changelog/db.changelog-master.yml
-    default-schema: p_delivery
-    liquibase-schema: p_delivery
   # Kafka — GKE namespace 'kafka' 의 StatefulSet 3 broker.
   # 현재 DEV 브랜치 사용 없음.
   # dependency 가 spring-kafka 라 auto-config 가 localhost:9092 로


### PR DESCRIPTION
## 🌱 설명

duplicate `liquibase:` 키로 YAML parse fail → pod CrashLoopBackOff. DB 자체는 schema 분리 완료 (p_delivery.databasechangelog 사용 중).

PR #31 의 첫 번째 블록 (schema 분리) 유지. 팀원 commit (`chore: liquibase 설정 추가`) 의 두 번째 블록 제거.

## ✅ 주요 변경 사항

- 두 번째 `liquibase:` 블록 (enabled / change-log / schema) 제거
- 첫 번째 `liquibase:` 블록 (default-schema + liquibase-schema) 유지

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

DB 상태:
- p_delivery.databasechangelog: 4 row (정상)
- p_delivery 의 모든 테이블 보존 (p_delivery_batches 1326 — 5초 스케줄러 누적)
- public.databasechangelog 충돌 회피 유지

inspection 도 같은 패턴 (별도 PR).