### PR TITLE
datasource url DB_HOST env 추가 (Cloud SQL 마이그)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -49,6 +49,12 @@ spec:
                 secretKeyRef:
                   name: domain-postgres-secrets
                   key: DB_PASSWORD
+            # DB_HOST — Cloud SQL Private IP (Secret 에서 주입). application-k8s.yml 의 ${DB_HOST:postgres} 와 대응.
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: domain-postgres-secrets
+                  key: DB_HOST
           # request 는 실 사용량 기반 (CPU ~25m, memory ~400Mi, burst 여유 포함).
           # limit 은 thread 800 stack (~800MB) + heap (limit*25%=500MB) + 기타 = ~1.5GB 안에 맞춤.
           # request 줄임 → 노드당 pod 수 증가 → HPA scale 자리 확보 (e2-medium 4Gi 노드 기준 3 pod/노드).

--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -22,7 +22,8 @@ spring:
       label: develop
       fail-fast: false
   datasource:
-    url: jdbc:postgresql://postgres:5432/trusta_market
+    # DB_HOST env 로 endpoint 주입 (Secret domain-postgres-secrets). default = postgres (in-cluster fallback).
+    url: jdbc:postgresql://${DB_HOST:postgres}:5432/trusta_market
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     # HikariCP pool — default 10 이 thread 800 대비 너무 작아서 thread 가 pool 대기.


### PR DESCRIPTION
domain-postgres-secrets 의 DB_HOST 로 endpoint 주입. Cloud SQL Private IP 가 manifest/코드에 노출 X. default = postgres (in-cluster fallback).