### PR TITLE
HikariCP pool 증액 (Cloud SQL 2500 안 분배)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -49,6 +49,12 @@ spec:
                 secretKeyRef:
                   name: domain-postgres-secrets
                   key: DB_PASSWORD
+            # DB_HOST — Cloud SQL Private IP (Secret 에서 주입). application-k8s.yml 의 ${DB_HOST:postgres} 와 대응.
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: domain-postgres-secrets
+                  key: DB_HOST
           # request 는 실 사용량 기반 (CPU ~25m, memory ~400Mi, burst 여유 포함).
           # limit 은 thread 800 stack (~800MB) + heap (limit*25%=500MB) + 기타 = ~1.5GB 안에 맞춤.
           # request 줄임 → 노드당 pod 수 증가 → HPA scale 자리 확보 (e2-medium 4Gi 노드 기준 3 pod/노드).

--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -26,10 +26,10 @@ spring:
     url: jdbc:postgresql://${DB_HOST:postgres}:5432/trusta_market
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
-    # HikariCP pool — default 10 이 thread 800 대비 너무 작아서 thread 가 pool 대기.
-    # postgres max_connections=700 안에서 7 DB service × pool 18 × HPA max 5 = 630 (안전선).
+    # HikariCP pool — Cloud SQL max_connections=2500 안에서 6 service 통일 + product 만 2배 (120).
+    # 합 = 6 × 60 × 5 + 5 × 120 = 2400 / 2500 ✓.
     hikari:
-      maximum-pool-size: 18
+      maximum-pool-size: 60
   # delivery / inspection 이 같은 V001__init.sql changeset (id 1-4, author seungwon) 을 쓰는데
   # 그 두 service 가 public.databasechangelog 공유하면 file 내용 다를 때 checksum mismatch.
   # → p_delivery schema 의 databasechangelog 으로 분리. p_delivery.databasechangelog row 는 별도 SQL 로 NULL md5 박아둠 (Liquibase 가 부팅 시 재계산).

--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -22,7 +22,8 @@ spring:
       label: develop
       fail-fast: false
   datasource:
-    url: jdbc:postgresql://postgres:5432/trusta_market
+    # DB_HOST env 로 endpoint 주입 (Secret domain-postgres-secrets). default = postgres (in-cluster fallback).
+    url: jdbc:postgresql://${DB_HOST:postgres}:5432/trusta_market
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     # HikariCP pool — default 10 이 thread 800 대비 너무 작아서 thread 가 pool 대기.


### PR DESCRIPTION
Cloud SQL max_connections 2500 안에서 product = 120, 다른 6 = 60. 합 2400/2500.