### PR TITLE
[refactor] API 응답 반환형 변경

### DIFF
--- a/src/main/java/com/trustamarket/deliveryservice/delivery/adapter/in/web/DeliveryApiController.java
+++ b/src/main/java/com/trustamarket/deliveryservice/delivery/adapter/in/web/DeliveryApiController.java
@@ -1,8 +1,10 @@
 package com.trustamarket.deliveryservice.delivery.adapter.in.web;
 
+import com.trustamarket.common.response.CommonResponse;
 import com.trustamarket.deliveryservice.delivery.adapter.in.web.dto.response.GetDeliveryStatusResponse;
 import com.trustamarket.deliveryservice.delivery.application.port.in.GetDeliveryStatusUseCase;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,7 +21,10 @@ public class DeliveryApiController {
     private final GetDeliveryStatusUseCase getDeliveryStatusUseCase;
 
     @GetMapping("/{deliveryId}/status")
-    public ResponseEntity<GetDeliveryStatusResponse> getDeliveryStatus(@PathVariable UUID deliveryId) {
-        return ResponseEntity.ok(GetDeliveryStatusResponse.from(getDeliveryStatusUseCase.get(deliveryId)));
+    public ResponseEntity<CommonResponse<GetDeliveryStatusResponse>> getDeliveryStatus(@PathVariable UUID deliveryId) {
+        return ResponseEntity.ok(CommonResponse.of(
+                HttpStatus.OK.value(),
+                GetDeliveryStatusResponse.from(getDeliveryStatusUseCase.get(deliveryId)))
+        );
     }
 }


### PR DESCRIPTION
## 🌱 설명

DeliveryApiController 내 메서드 반환형을 변경했습니다.

## 📌 관련 이슈

close #40 

## ✅ 주요 변경 사항

- DeliveryApiController 내 메서드 반환형 변경

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the delivery status API endpoint response structure to use a standardized wrapper format with consistent metadata. The endpoint now includes response metadata alongside delivery information, ensuring uniform API behavior and improving the overall integration experience for API consumers by providing predictable and consistent response structures across all endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/delivery-service/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->