### PR TITLE
[feature] OutboxPoller SKIP LOCKED 분산 폴러 도입

### DIFF
--- a/src/main/java/com/trustamarket/deliveryservice/delivery/adapter/out/messaging/OutboxClaimAdapter.java
+++ b/src/main/java/com/trustamarket/deliveryservice/delivery/adapter/out/messaging/OutboxClaimAdapter.java
@@ -1,0 +1,28 @@
+package com.trustamarket.deliveryservice.delivery.adapter.out.messaging;
+
+import com.trustamarket.deliveryservice.delivery.adapter.out.persistence.jpa.DeliveryOutboxJpaEntity;
+import com.trustamarket.deliveryservice.delivery.adapter.out.persistence.jpa.DeliveryOutboxJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class OutboxClaimAdapter {
+
+    private final DeliveryOutboxJpaRepository outboxJpaRepository;
+
+    @Transactional
+    public List<DeliveryOutboxJpaEntity> claim(int batchSize) {
+        List<DeliveryOutboxJpaEntity> pending =
+                outboxJpaRepository.findPendingForUpdateSkipLocked(batchSize);
+        if (pending.isEmpty()) {
+            return pending;
+        }
+        pending.forEach(DeliveryOutboxJpaEntity::markInProgress);
+        outboxJpaRepository.saveAll(pending);
+        return pending;
+    }
+}

--- a/src/main/java/com/trustamarket/deliveryservice/delivery/adapter/out/messaging/OutboxPoller.java
+++ b/src/main/java/com/trustamarket/deliveryservice/delivery/adapter/out/messaging/OutboxPoller.java
@@ -3,6 +3,9 @@ package com.trustamarket.deliveryservice.delivery.adapter.out.messaging;
 import com.trustamarket.deliveryservice.delivery.adapter.out.persistence.jpa.DeliveryOutboxJpaEntity;
 import com.trustamarket.deliveryservice.delivery.adapter.out.persistence.jpa.DeliveryOutboxJpaRepository;
 import com.trustamarket.deliveryservice.delivery.adapter.out.persistence.jpa.OutboxStatus;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -20,22 +23,30 @@ public class OutboxPoller {
 
     private final DeliveryOutboxJpaRepository outboxJpaRepository;
     private final KafkaTemplate<String, String> kafkaTemplate;
+    private final OutboxClaimAdapter outboxClaimAdapter;
+    private final MeterRegistry meterRegistry;
 
     @Value("${delivery.outbox.max-retries:3}")
     private int maxRetries;
 
+    @Value("${delivery.outbox.batch-size:500}")
+    private int batchSize;
+
+    @PostConstruct
+    void registerMetrics() {
+        Gauge.builder("delivery.outbox.pending.depth",
+                () -> (double) outboxJpaRepository.countByStatus(OutboxStatus.PENDING))
+            .register(meterRegistry);
+    }
+
     @Scheduled(cron = "${delivery.outbox.scheduler-cron}")
     public void poll() {
-        List<DeliveryOutboxJpaEntity> pending =
-                outboxJpaRepository.findTop500ByStatusOrderByCreatedAtAsc(OutboxStatus.PENDING);
-        if (pending.isEmpty()) {
+        List<DeliveryOutboxJpaEntity> claimed = outboxClaimAdapter.claim(batchSize);
+        if (claimed.isEmpty()) {
             return;
         }
 
-        pending.forEach(DeliveryOutboxJpaEntity::markInProgress);
-        outboxJpaRepository.saveAll(pending);
-
-        for (DeliveryOutboxJpaEntity entry : pending) {
+        for (DeliveryOutboxJpaEntity entry : claimed) {
             try {
                 kafkaTemplate.send(entry.getTopic(), entry.getMessageKey(), entry.getPayload())
                         .get(5, TimeUnit.SECONDS);

--- a/src/main/java/com/trustamarket/deliveryservice/delivery/adapter/out/persistence/jpa/DeliveryOutboxJpaRepository.java
+++ b/src/main/java/com/trustamarket/deliveryservice/delivery/adapter/out/persistence/jpa/DeliveryOutboxJpaRepository.java
@@ -1,11 +1,22 @@
 package com.trustamarket.deliveryservice.delivery.adapter.out.persistence.jpa;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.UUID;
 
 public interface DeliveryOutboxJpaRepository extends JpaRepository<DeliveryOutboxJpaEntity, UUID> {
 
-    List<DeliveryOutboxJpaEntity> findTop500ByStatusOrderByCreatedAtAsc(OutboxStatus status);
+    @Query(value = """
+            SELECT * FROM p_delivery.p_delivery_outbox
+            WHERE status = 'PENDING'
+            ORDER BY created_at
+            LIMIT :limit
+            FOR UPDATE SKIP LOCKED
+            """, nativeQuery = true)
+    List<DeliveryOutboxJpaEntity> findPendingForUpdateSkipLocked(@Param("limit") int limit);
+
+    long countByStatus(OutboxStatus status);
 }


### PR DESCRIPTION
## 🌱 설명

OutboxPoller SKIP LOCKED 분산 폴러를 도입했습니다.

## 📌 관련 이슈

close #44 

## ✅ 주요 변경 사항

- SKIP LOCKED native query

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metrics visibility for pending delivery messages in the outbox system.
  * Introduced configurable batch size for message processing (`delivery.outbox.batch-size`, default 500).

* **Improvements**
  * Enhanced concurrent message processing to safely handle multiple consumers without contention.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/delivery-service/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->