### PR TITLE
[feature] Kafka 이벤트에 eventId 추가 (소비자 멱등성 지원)

### DIFF
--- a/src/main/java/com/trustamarket/deliveryservice/delivery/adapter/out/messaging/CarrierDeliveryCompletedKafkaEvent.java
+++ b/src/main/java/com/trustamarket/deliveryservice/delivery/adapter/out/messaging/CarrierDeliveryCompletedKafkaEvent.java
@@ -3,6 +3,7 @@ package com.trustamarket.deliveryservice.delivery.adapter.out.messaging;
 import java.util.UUID;
 
 record CarrierDeliveryCompletedKafkaEvent(
+        UUID eventId,
         UUID productId
 ) {
 }

--- a/src/main/java/com/trustamarket/deliveryservice/delivery/adapter/out/messaging/CarrierReturnCompletedKafkaEvent.java
+++ b/src/main/java/com/trustamarket/deliveryservice/delivery/adapter/out/messaging/CarrierReturnCompletedKafkaEvent.java
@@ -3,6 +3,7 @@ package com.trustamarket.deliveryservice.delivery.adapter.out.messaging;
 import java.util.UUID;
 
 record CarrierReturnCompletedKafkaEvent(
+        UUID eventId,
         UUID productId
 ) {
 }

--- a/src/main/java/com/trustamarket/deliveryservice/delivery/adapter/out/messaging/KafkaDeliveryEventPublisher.java
+++ b/src/main/java/com/trustamarket/deliveryservice/delivery/adapter/out/messaging/KafkaDeliveryEventPublisher.java
@@ -28,14 +28,15 @@ public class KafkaDeliveryEventPublisher implements DeliveryEventPublisher {
 
     @Override
     public void publishCarrierDeliveryCompleted(UUID productId) {
+        // inspection-service Inbox 멱등성 키 — Outbox row가 한 번 생성되므로 재발행돼도 동일 eventId 유지.
         saveToOutbox(CARRIER_DELIVERY_COMPLETED_TOPIC, productId.toString(),
-                new CarrierDeliveryCompletedKafkaEvent(productId));
+                new CarrierDeliveryCompletedKafkaEvent(UUID.randomUUID(), productId));
     }
 
     @Override
     public void publishCarrierReturnCompleted(UUID productId) {
         saveToOutbox(CARRIER_RETURN_COMPLETED_TOPIC, productId.toString(),
-                new CarrierReturnCompletedKafkaEvent(productId));
+                new CarrierReturnCompletedKafkaEvent(UUID.randomUUID(), productId));
     }
 
     @Override


### PR DESCRIPTION
## 🌱 설명

Kafka 이벤트에 eventId 필드를 추가했습니다.

## 📌 관련 이슈

close #46 

## ✅ 주요 변경 사항

- 필드 추가

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the internal event messaging system for delivery and return operations by introducing unique event identifiers to improve tracking consistency across the platform.
  * Updated event publishing mechanisms for carrier operations to generate and maintain distinct event IDs throughout the message processing lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->